### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,15 +2,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MS5803 	KEYWORD1
+MS5803	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 getTemperature	KEYWORD2
-getPressure		KEYWORD2
-reset			KEYWORD2
+getPressure	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
@@ -18,14 +18,13 @@ reset			KEYWORD2
 
 
 FAHRENHEIT	LITERAL1
-CELSIUS		LITERAL1
+CELSIUS	LITERAL1
 
 ADDRESS_HIGH	LITERAL1
-ADDRESS_LOW		LITERAL1
+ADDRESS_LOW	LITERAL1
 
-ADC_256 	LITERAL1
-ADC_512 	LITERAL1
+ADC_256	LITERAL1
+ADC_512	LITERAL1
 ADC_1024	LITERAL1
 ADC_2048	LITERAL1
 ADC_4096	LITERAL1
-    


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords